### PR TITLE
Mostly working!

### DIFF
--- a/nginx/init.sls
+++ b/nginx/init.sls
@@ -27,11 +27,11 @@ nginx:
     - mode: 644
 
 # Newer versions of nginx make this directory .../html so we have to make sure.
-/usr/share/nginx/www:
-  file.directory:
-    - user: root
-    - group: www-data
-    - mode: 644
+#/usr/share/nginx/www:
+#  file.directory:
+#    - user: root
+#    - group: www-data
+#    - mode: 644
 
 {% if pillar['tm_nginxurlssource'] is defined %}
 nginxurls:

--- a/osm/postgis.sls
+++ b/osm/postgis.sls
@@ -11,7 +11,7 @@ config_postgis:
     - watch: [ pkg: install_postgis_pkgs ]
     - require: [ service: postgresql ]
     # If we can already connect to a gis database, we don't need to do this.
-    - unless: sudo -u postgres psql -d gis -c '' 2>/dev/null
+    #- unless: sudo -u postgres psql -d gis -c '' 2>/dev/null
 
 postgis_logdone:
   cmd.wait_script:

--- a/osm/update_data.sls
+++ b/osm/update_data.sls
@@ -13,8 +13,8 @@ do_import:
     # All of this mess is about preventing the import holding up the whole deployment.
     - name: echo './import.sh > import.log && ./process.sh >> import.log' | at now +1 minute
     - cwd: {{pillar['tm_dir']}}
-    - user: ubuntu
-    - group: ubuntu
+    - user: root
+    - group: root
     - watch: [ cmd: update_data ] # Only import if we have fresh .pbf
     - require: [ pkg: install_at, sls: osm.postgis ]
 

--- a/osrm/osrminstall.sls
+++ b/osrm/osrminstall.sls
@@ -82,7 +82,7 @@ osrm_memlock:
 osrm_pam:
   file.uncomment:
     - name: /etc/pam.d/su
-    - regex: "session    required   pam_limits.so"
+    - regex: " session    required   pam_limits.so"
 
 osrm_logdone:
   cmd.wait_script:


### PR DESCRIPTION
This code is safe to be in both master and stable branches; I've run it several times today on a basically fresh system (resetting to a clean snapshot after each test), and the only thing that fails now is osrm_reindex_bicycle as shown below.

I've confirmed that I can import all the Australasian map data, all the DEMs, for Australasia, the Azerbaijan map data, and both the sample TileMill projects. I then changed the Melbourne TileMill project's project.mml to use my local PostGIS database, and that was successful. The build took about 2 hours on the VM I'm using (which has 8GB RAM, and a single core of a Core i5 2.9GHz CPU).
It only took me about 12 hours to get everything sorted out, so that's good :-/.

Please review the diff before applying it anyway, and ask questions if anything doesn't look right or if the commit messages are too vague.

```
----------
          ID: osrm_reindex_bicycle
    Function: cmd.wait
        Name: ./osrm-extract extract.osm.pbf # creates .names, ., .restrictions
./osrm-prepare extract.osrm # creates .fileIndex, .hsgr, .nodes, .ramIndex, .edges
sleep 2
test -f extract.osrm.hsgr || ( echo "OSRM extract failed somehow." && exit 1 )
pkill -f 'osrm-routed.*-p 5010' # Make sure we kill the right instance.
# nohup ./osrm-routed -p 5010 -t 8 extract.osrm > /dev/null 2>&1 & 
/mnt/saltymill/log.sh "OSRM index for profile 'Bike' rebuilt."

      Result: False
     Comment: Command "./osrm-extract extract.osm.pbf # creates .names, ., .restrictions
              ./osrm-prepare extract.osrm # creates .fileIndex, .hsgr, .nodes, .ramIndex, .edges
              sleep 2
              test -f extract.osrm.hsgr || ( echo "OSRM extract failed somehow." && exit 1 )
              pkill -f 'osrm-routed.*-p 5010' # Make sure we kill the right instance.
              # nohup ./osrm-routed -p 5010 -t 8 extract.osrm > /dev/null 2>&1 & 
              /mnt/saltymill/log.sh "OSRM index for profile 'Bike' rebuilt."
              " run
     Started: 22:10:22.562209
    Duration: 2436.441 ms
     Changes:   
```
